### PR TITLE
adding get() wrapper to base class

### DIFF
--- a/cloudsecrets/__init__.py
+++ b/cloudsecrets/__init__.py
@@ -48,6 +48,9 @@ class SecretsBase:
         else:
             self._load_secrets()
 
+    def get(self,*args,**kwargs):
+        return dict(self).get(*args,**kwargs)
+
     def _list_versions(self) -> list:
         return [self._version]
 


### PR DESCRIPTION
This lets one use get() the same way they would if they were using a dict, without needing to convert the object to a dict first.

Old way:
```
s = Secrets("my-secret")
var = dict(s).get("my-key")
```
New way:
```
s = Secrets("my-secret")
var = s.get("my-key")
```
fyi @bowlofstew 