### PR TITLE
adding @mock_secretsmanager to setUpClass in aws test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /app
 
 COPY . /app
 
-RUN python setup.py build test install
+RUN pip3 install . && tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,11 @@ python = ">=3.4"
 google-cloud-secret-manager = "*"
 boto3 = "*"
 simplejson = "*"
+tox = "*"
 
 [tool.poetry.dev-dependencies]
 moto = "*"
+nose = "*"
 
 [tool.poetry.scripts]
 cloud-secrets = "cloudsecrets.cli:main"

--- a/tests/unit/test_aws_library.py
+++ b/tests/unit/test_aws_library.py
@@ -13,6 +13,7 @@ class TestAWSLibrary(unittest.TestCase):
     from moto import mock_secretsmanager
 
     @classmethod
+    @mock_secretsmanager
     def setUpClass(self):
         self.secret_name = "FAKE_SECRET_NAME"
         self.secret_key = "FAKE"


### PR DESCRIPTION
I noticed while building a cloudsecrets base image the aws tests were broken, so I've attempted to address that and improve the commands used to build the docker image, since they've changed a bit over time. 

@bowlofstew Can you validate my approach here for fixing the test? 