### PR TITLE
Pinning GCSM to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Adam Frank <afrank@mozilla.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.4"
-google-cloud-secret-manager = "*"
+google-cloud-secret-manager = "1.0.0"
 boto3 = "*"
 simplejson = "*"
 tox = "*"


### PR DESCRIPTION
Regarding issue incurring in downstream services that use this dependency. https://github.com/mozilla-it/cloudsecrets/issues/35

Locking to 1.0.0 for google-cloud-secret-manager 